### PR TITLE
Add pytest tests for weather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ This Flask app was created by Gaurav Aryal.
 
 **License**  
 This app is open-source and available under the MIT license.
+## Running Tests
+To execute the test suite, run the following command from the project root:
+
+```bash
+pytest
+```

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,39 @@
+import json
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unittest.mock import patch, MagicMock
+from weatherAPI import app
+
+
+def test_get_weather_by_name_missing_city_returns_400():
+    client = app.test_client()
+    response = client.get('/get_weather_by_name')
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data['error']
+
+
+def test_get_weather_by_name_success_with_mocking():
+    with patch('weatherAPI.geolocator.geocode') as geocode_mock, \
+         patch('weatherAPI.requests.get') as requests_get:
+        geocode_mock.return_value = MagicMock(latitude=52.52, longitude=13.405)
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            'current_weather': {
+                'temperature': 20,
+                'humidity': 60,
+                'windspeed': 5,
+                'winddirection': 90
+            }
+        }
+        requests_get.return_value = mock_resp
+
+        client = app.test_client()
+        response = client.get('/get_weather_by_name?city=Berlin')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['city'] == 'Berlin'
+        assert data['temperature'] == 20
+        assert data['humidity'] == 60
+        assert data['windspeed'] == 5
+        assert data['winddirection'] == 90


### PR DESCRIPTION
## Summary
- add Flask test client tests for `get_weather_by_name`
- document running the tests with pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841ef1ee7ac8329a6cec92ffab026d0